### PR TITLE
Allow Custom CA Bundle Paths

### DIFF
--- a/changelog/@unreleased/pr-4.v2.yml
+++ b/changelog/@unreleased/pr-4.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Allow Custom CA Bundle Paths
+  links:
+  - https://github.com/palantir/external-systems/pull/4

--- a/external_systems/sources/_sources.py
+++ b/external_systems/sources/_sources.py
@@ -29,6 +29,7 @@ from ._connections import HttpsConnection
 from ._proxies import create_proxy_session
 from ._refreshable import DefaultSessionCredentialsManager, Refreshable, RefreshHandler
 from ._sockets import create_socket
+from ._utils import read_file
 
 log = logging.getLogger(__name__)
 
@@ -46,6 +47,7 @@ class Source:
         egress_proxy_token: Optional[str],
         source_configuration: Optional[Any],
         credentials_refresh_handler: Optional[RefreshHandler[SourceCredentials]] = None,
+        ca_bundle_path: Optional[str] = None,
     ):
         self._source_parameters = source_parameters
         self._on_prem_proxy_service_uris = on_prem_proxy_service_uris
@@ -53,6 +55,7 @@ class Source:
         self._source_configuration = source_configuration
         self._egress_proxy_token = egress_proxy_token
         self._credentials_refresh_handler = credentials_refresh_handler
+        self._custom_ca_bundle_path = ca_bundle_path
 
     @cached_property
     def secrets(self) -> Mapping[str, str]:
@@ -84,11 +87,17 @@ class Source:
 
         new_ca_contents = []
 
-        # If requests env var is set, add all existing CAs
-        requests_ca_bundle_path = os.environ.get("REQUESTS_CA_BUNDLE")
-        if requests_ca_bundle_path is not None:
-            with open(requests_ca_bundle_path) as requests_ca_bundle_file:
-                new_ca_contents.append(requests_ca_bundle_file.read())
+        # If a custom CA bundle path is provided, use it.
+        # Otherwise, use the requests CA bundle path if it is set.
+        ca_bundle_path = (
+            self._custom_ca_bundle_path
+            if self._custom_ca_bundle_path is not None
+            else os.environ.get("REQUESTS_CA_BUNDLE")
+        )
+
+        # Copy the CA bundle contents to the new CA bundle file.
+        if ca_bundle_path:
+            new_ca_contents.append(read_file(ca_bundle_path))
 
         # Add all CAs for the source
         for required_ca in self._source_parameters.server_certificates.values():

--- a/external_systems/sources/_utils.py
+++ b/external_systems/sources/_utils.py
@@ -23,3 +23,8 @@ def has_expiration_property(source_credentials: SourceCredentials) -> bool:
     """
 
     return hasattr(source_credentials, "expiration")
+
+
+def read_file(path: str) -> str:
+    with open(path) as file:
+        return file.read()

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -197,6 +197,43 @@ def test_ca_bundle_path_creation_for_server_certificates_with_no_default_ca_conf
         assert "server_ca_value" in ca_contents
 
 
+def test_ca_bundle_path_creation_for_server_certificates_uses_custom_ca_bundle_path(
+    source_params: SourceParameters, on_prem_proxy_uris: list[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("REQUESTS_CA_BUNDLE")
+    with NamedTemporaryFile(delete=False, mode="w") as default_ca:
+        default_ca.write("my_ca_value\n")
+
+    source = Source(source_params, on_prem_proxy_uris, [], None, None, ca_bundle_path=default_ca.name)
+    ca_bundle_path = source._ca_bundle_path
+
+    assert ca_bundle_path is not None
+    with open(ca_bundle_path) as f:
+        ca_contents = f.read()
+        assert "my_ca_value" in ca_contents
+        assert "server_ca_value" in ca_contents
+
+
+def test_ca_bundle_path_creation_does_not_use_requests_ca_bundle_if_custom_ca_bundle_configured(
+    source_params: SourceParameters, on_prem_proxy_uris: list[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    with NamedTemporaryFile(delete=False, mode="w") as requests_ca_bundle:
+        requests_ca_bundle.write("requests_ca_bundle_value\n")
+        monkeypatch.setenv("REQUESTS_CA_BUNDLE", requests_ca_bundle.name)
+
+    with NamedTemporaryFile(delete=False, mode="w") as default_ca:
+        default_ca.write("default_ca_value\n")
+
+    source = Source(source_params, on_prem_proxy_uris, [], None, None, ca_bundle_path=default_ca.name)
+    ca_bundle_path = source._ca_bundle_path
+
+    assert ca_bundle_path is not None
+    with open(ca_bundle_path) as f:
+        ca_contents = f.read()
+        assert "default_ca_value" in ca_contents
+        assert "server_ca_value" in ca_contents
+
+
 @patch("external_systems.sources._sources.create_socket")
 def test_create_socket(
     mock_create_socket: MagicMock,

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -12,6 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+import os
 from tempfile import NamedTemporaryFile
 from typing import Any
 from unittest.mock import MagicMock, patch
@@ -200,7 +201,8 @@ def test_ca_bundle_path_creation_for_server_certificates_with_no_default_ca_conf
 def test_ca_bundle_path_creation_for_server_certificates_uses_custom_ca_bundle_path(
     source_params: SourceParameters, on_prem_proxy_uris: list[str], monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    monkeypatch.delenv("REQUESTS_CA_BUNDLE")
+    if "REQUESTS_CA_BUNDLE" in os.environ:
+        monkeypatch.delenv("REQUESTS_CA_BUNDLE")
     with NamedTemporaryFile(delete=False, mode="w") as default_ca:
         default_ca.write("my_ca_value\n")
 


### PR DESCRIPTION
## After this PR
Allow consumers of the library to provide a custom CA bundle path when the default environment variable used by the requests library is not available.