### PR TITLE
Fix ca_bundle gen

### DIFF
--- a/changelog/@unreleased/pr-9.v2.yml
+++ b/changelog/@unreleased/pr-9.v2.yml
@@ -1,5 +1,5 @@
 type: fix
 fix:
-  description: Fix ca_bundle gen
+  description: Fix ca_bundle usage in Python requests Session object
   links:
   - https://github.com/palantir/external-systems/pull/9

--- a/changelog/@unreleased/pr-9.v2.yml
+++ b/changelog/@unreleased/pr-9.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Fix ca_bundle gen
+  links:
+  - https://github.com/palantir/external-systems/pull/9

--- a/external_systems/sources/_proxies.py
+++ b/external_systems/sources/_proxies.py
@@ -20,7 +20,7 @@ from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
 
-class WrappedSession(Session):
+class CustomCaBundleSession(Session):
     """
     A wrapper for requests.Session to override 'verify' property, ignoring REQUESTS_CA_BUNDLE environment variable.
 
@@ -31,7 +31,9 @@ class WrappedSession(Session):
         if isinstance(self.verify, str):
             verify = self.verify
 
-        return super(WrappedSession, self).merge_environment_settings(url, proxies, stream, verify, *args, **kwargs)
+        return super(CustomCaBundleSession, self).merge_environment_settings(
+            url, proxies, stream, verify, *args, **kwargs
+        )
 
 
 class RetryingTimeoutHttpAdapter(HTTPAdapter):
@@ -97,7 +99,7 @@ def create_proxy_session(proxy_url: str, proxy_token: str) -> Session:
     """
 
     adapter = ProxyAdapter(proxy_auth={proxy_url: f"Bearer {proxy_token}"})
-    session = WrappedSession()
+    session = CustomCaBundleSession()
     session.mount("http://", adapter)
     session.mount("https://", adapter)
     session.proxies = {"all": proxy_url}
@@ -124,7 +126,7 @@ def create_session(
         timeout (Optional[Union[float, tuple[float, float], tuple[float, None]]]): Timeout settings for the session.
     """
 
-    session = WrappedSession()
+    session = CustomCaBundleSession()
 
     if cert:
         session.cert = cert

--- a/external_systems/sources/_proxies.py
+++ b/external_systems/sources/_proxies.py
@@ -27,7 +27,7 @@ class WrappedSession(Session):
     This is a workaround for https://github.com/kennethreitz/requests/issues/3829 (will be fixed in requests 3.0.0)
     """
 
-    def merge_environment_settings(self, url, proxies, stream, verify, *args, **kwargs):
+    def merge_environment_settings(self, url, proxies, stream, verify, *args, **kwargs):  # type: ignore[no-untyped-def]
         if isinstance(self.verify, str):
             verify = self.verify
 

--- a/external_systems/sources/_proxies.py
+++ b/external_systems/sources/_proxies.py
@@ -20,6 +20,19 @@ from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
 
+class WrappedSession(Session):
+    """
+    A wrapper for requests.Session to override 'verify' property, ignoring REQUESTS_CA_BUNDLE environment variable.
+
+    This is a workaround for https://github.com/kennethreitz/requests/issues/3829 (will be fixed in requests 3.0.0)
+    """
+    def merge_environment_settings(self, url, proxies, stream, verify, *args, **kwargs):
+        if isinstance(self.verify, str):
+            verify = self.verify
+
+        return super(WrappedSession, self).merge_environment_settings(url, proxies, stream, verify, *args, **kwargs)
+
+
 class RetryingTimeoutHttpAdapter(HTTPAdapter):
     def __init__(
         self,
@@ -83,7 +96,7 @@ def create_proxy_session(proxy_url: str, proxy_token: str) -> Session:
     """
 
     adapter = ProxyAdapter(proxy_auth={proxy_url: f"Bearer {proxy_token}"})
-    session = Session()
+    session = WrappedSession()
     session.mount("http://", adapter)
     session.mount("https://", adapter)
     session.proxies = {"all": proxy_url}
@@ -110,7 +123,7 @@ def create_session(
         timeout (Optional[Union[float, tuple[float, float], tuple[float, None]]]): Timeout settings for the session.
     """
 
-    session = Session()
+    session = WrappedSession()
 
     if cert:
         session.cert = cert

--- a/external_systems/sources/_proxies.py
+++ b/external_systems/sources/_proxies.py
@@ -26,6 +26,7 @@ class WrappedSession(Session):
 
     This is a workaround for https://github.com/kennethreitz/requests/issues/3829 (will be fixed in requests 3.0.0)
     """
+
     def merge_environment_settings(self, url, proxies, stream, verify, *args, **kwargs):
         if isinstance(self.verify, str):
             verify = self.verify

--- a/external_systems/sources/_proxies.py
+++ b/external_systems/sources/_proxies.py
@@ -24,7 +24,7 @@ class WrappedSession(Session):
     """
     A wrapper for requests.Session to override 'verify' property, ignoring REQUESTS_CA_BUNDLE environment variable.
 
-    This is a workaround for https://github.com/kennethreitz/requests/issues/3829 (will be fixed in requests 3.0.0)
+    This is a workaround for https://github.com/psf/requests/issues/3829 (will be fixed in requests 3.0.0)
     """
 
     def merge_environment_settings(self, url, proxies, stream, verify, *args, **kwargs):  # type: ignore[no-untyped-def]

--- a/external_systems/sources/_sources.py
+++ b/external_systems/sources/_sources.py
@@ -104,7 +104,7 @@ class Source:
             new_ca_contents.append(required_ca)
 
         with NamedTemporaryFile(delete=False, mode="w") as ca_bundle_file:
-            ca_bundle_file.write(os.linesep.join(new_ca_contents) + os.linesep)
+            ca_bundle_file.write("".join(new_ca_contents) + os.linesep)
             return ca_bundle_file.name
 
     @cached_property

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -179,8 +179,7 @@ def test_ca_bundle_path_creation_for_server_certificates_with_default_ca_configu
     assert ca_bundle_path is not None
     with open(ca_bundle_path) as f:
         ca_contents = f.read()
-        assert "default_ca_value" in ca_contents
-        assert "server_ca_value" in ca_contents
+        assert ca_contents == "default_ca_value\nserver_ca_value\n"
 
 
 def test_ca_bundle_path_creation_for_server_certificates_with_no_default_ca_configured(
@@ -194,7 +193,7 @@ def test_ca_bundle_path_creation_for_server_certificates_with_no_default_ca_conf
     assert ca_bundle_path is not None
     with open(ca_bundle_path) as f:
         ca_contents = f.read()
-        assert "server_ca_value" in ca_contents
+        assert ca_contents == "server_ca_value\n"
 
 
 def test_ca_bundle_path_creation_for_server_certificates_uses_custom_ca_bundle_path(
@@ -210,8 +209,7 @@ def test_ca_bundle_path_creation_for_server_certificates_uses_custom_ca_bundle_p
     assert ca_bundle_path is not None
     with open(ca_bundle_path) as f:
         ca_contents = f.read()
-        assert "my_ca_value" in ca_contents
-        assert "server_ca_value" in ca_contents
+        assert ca_contents == "my_ca_value\nserver_ca_value\n"
 
 
 def test_ca_bundle_path_creation_does_not_use_requests_ca_bundle_if_custom_ca_bundle_configured(
@@ -230,8 +228,7 @@ def test_ca_bundle_path_creation_does_not_use_requests_ca_bundle_if_custom_ca_bu
     assert ca_bundle_path is not None
     with open(ca_bundle_path) as f:
         ca_contents = f.read()
-        assert "default_ca_value" in ca_contents
-        assert "server_ca_value" in ca_contents
+        assert ca_contents == "default_ca_value\nserver_ca_value\n"
 
 
 @patch("external_systems.sources._sources.create_socket")


### PR DESCRIPTION
## Before this PR
SSL/TLS issues arising when users try to use custom server certificates

Context here: https://github.com/psf/requests/issues/3829

The python requests `Session` object actually puts precedence on env vars like `REQUESTS_CA_BUNDLE` over the verify property on the object itself. This means in ALL environments where we set that ENV var (which is the majority), the HTTP client we provide will never work if the source requires server certificate provided by the user

## After this PR

Wrap the Session object and give precedence to the `verify` if it is set

## Alternative
- Write source certs to the original `REQUESTS_CA_BUNDLE` or the provided bundle. I'm against this for a couple reasons
	- We should keep certificates per requests mapped 1:1 with their corresponding source (better separation)
	- Avoids possible write conflicts / issues that could occur if all sources are writing to this file