### PR TITLE
Refactor ca implementation

### DIFF
--- a/changelog/@unreleased/pr-11.v2.yml
+++ b/changelog/@unreleased/pr-11.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Refactor ca implementation
+  links:
+  - https://github.com/palantir/external-systems/pull/11

--- a/external_systems/sources/_sources.py
+++ b/external_systems/sources/_sources.py
@@ -81,22 +81,54 @@ class Source:
 
     @cached_property
     def _ca_bundle_path(self) -> Optional[str]:
-        if self._source_parameters.server_certificates is None:
-            return None
+        """
+        Returns the path to the CA bundle file with all custom CA certificates defined in the Source.
 
-        # Precedence of which CA bundle to use for the Session object:
-        # 1. Custom CA bundle path (if provided we assume PEM format)
-        # 2. Requests CA bundle path
-        # 3. Temporary file
-        ca_bundle_path = (
-            self._custom_ca_bundle_path
-            or os.environ.get("REQUESTS_CA_BUNDLE")
-            or NamedTemporaryFile(delete=False, mode="w").name
-        )
+        Precedence of which CA bundle to use:
+        1. Custom CA bundle path (if provided assumes PEM format)
+        2. Requests CA bundle path
+        3. Temporary file
+        """
 
-        server_certificates = self._source_parameters.server_certificates.values()
-        with open(ca_bundle_path, "a") as ca_bundle_file:
-            ca_bundle_file.write(os.linesep.join(server_certificates) + os.linesep)
+        provided_ca_bundle_path = self._custom_ca_bundle_path or os.environ.get("REQUESTS_CA_BUNDLE")
+
+        if not self._source_parameters.server_certificates:
+            return provided_ca_bundle_path
+
+        # Certificates from the Source to add to the CA bundle
+        server_certificates = list(self._source_parameters.server_certificates.values())
+
+        # If no provided CA bundle path, create a temporary file with only the server certificates
+        if not provided_ca_bundle_path:
+            with NamedTemporaryFile(delete=False, mode="w") as ca_bundle_file:
+                ca_bundle_file.write(os.linesep.join(server_certificates) + os.linesep)
+                return ca_bundle_file.name
+
+        # See https://docs.python.org/3/library/os.html#os.access for why we don't use os.access
+        # First try appending the server certificates to the provided CA bundle path
+        try:
+            with open(provided_ca_bundle_path, "a") as provided_ca_bundle_file:
+                provided_ca_bundle_file.write(os.linesep.join(server_certificates) + os.linesep)
+                return provided_ca_bundle_path
+        except PermissionError:
+            log.warning("PermissionError when writing to provided CA bundle path, falling back to temporary file.")
+
+        # Second try reading the provided CA bundle path and appending all content to the new CA bundle
+        new_ca_contents = []
+        try:
+            with open(provided_ca_bundle_path) as provided_ca_bundle_file:
+                new_ca_contents.append(provided_ca_bundle_file.read())
+        except PermissionError:
+            log.warning(
+                "PermissionError when reading from provided CA bundle path, falling back to temporary file with only the Source defined certificates."
+            )
+
+        # Finally, if no permissions to read or write to the provided CA bundle path, create a temporary file with only the Source defined certificates
+        for required_ca in self._source_parameters.server_certificates.values():
+            new_ca_contents.append(required_ca)
+
+        with NamedTemporaryFile(delete=False, mode="w") as ca_bundle_file:
+            ca_bundle_file.write(os.linesep.join(new_ca_contents) + os.linesep)
             return ca_bundle_file.name
 
     @cached_property

--- a/external_systems/sources/_sources.py
+++ b/external_systems/sources/_sources.py
@@ -113,17 +113,11 @@ class Source:
         except PermissionError:
             log.warning("PermissionError when writing to provided CA bundle path, falling back to temporary file.")
 
-        # Second try reading the provided CA bundle path and appending all content to the new CA bundle
+        # Finally, try reading the provided CA bundle path and appending all content to the new CA bundle
         new_ca_contents = []
-        try:
-            with open(provided_ca_bundle_path) as provided_ca_bundle_file:
-                new_ca_contents.append(provided_ca_bundle_file.read())
-        except PermissionError:
-            log.warning(
-                "PermissionError when reading from provided CA bundle path, falling back to temporary file with only the Source defined certificates."
-            )
+        with open(provided_ca_bundle_path) as provided_ca_bundle_file:
+            new_ca_contents.append(provided_ca_bundle_file.read())
 
-        # Finally, if no permissions to read or write to the provided CA bundle path, create a temporary file with only the Source defined certificates
         for required_ca in self._source_parameters.server_certificates.values():
             new_ca_contents.append(required_ca)
 

--- a/external_systems/sources/_sources.py
+++ b/external_systems/sources/_sources.py
@@ -29,7 +29,6 @@ from ._connections import HttpsConnection
 from ._proxies import create_proxy_session
 from ._refreshable import DefaultSessionCredentialsManager, Refreshable, RefreshHandler
 from ._sockets import create_socket
-from ._utils import read_file
 
 log = logging.getLogger(__name__)
 
@@ -85,26 +84,19 @@ class Source:
         if self._source_parameters.server_certificates is None:
             return None
 
-        new_ca_contents = []
-
-        # If a custom CA bundle path is provided, use it.
-        # Otherwise, use the requests CA bundle path if it is set.
+        # Precedence of which CA bundle to use for the Session object:
+        # 1. Custom CA bundle path (if provided we assume PEM format)
+        # 2. Requests CA bundle path
+        # 3. Temporary file
         ca_bundle_path = (
             self._custom_ca_bundle_path
-            if self._custom_ca_bundle_path is not None
-            else os.environ.get("REQUESTS_CA_BUNDLE")
+            or os.environ.get("REQUESTS_CA_BUNDLE")
+            or NamedTemporaryFile(delete=False, mode="w").name
         )
 
-        # Copy the CA bundle contents to the new CA bundle file.
-        if ca_bundle_path:
-            new_ca_contents.append(read_file(ca_bundle_path))
-
-        # Add all CAs for the source
-        for required_ca in self._source_parameters.server_certificates.values():
-            new_ca_contents.append(required_ca)
-
-        with NamedTemporaryFile(delete=False, mode="w") as ca_bundle_file:
-            ca_bundle_file.write(os.linesep.join(new_ca_contents) + os.linesep)
+        server_certificates = self._source_parameters.server_certificates.values()
+        with open(ca_bundle_path, "a") as ca_bundle_file:
+            ca_bundle_file.write(os.linesep.join(server_certificates) + os.linesep)
             return ca_bundle_file.name
 
     @cached_property

--- a/external_systems/sources/_utils.py
+++ b/external_systems/sources/_utils.py
@@ -23,8 +23,3 @@ def has_expiration_property(source_credentials: SourceCredentials) -> bool:
     """
 
     return hasattr(source_credentials, "expiration")
-
-
-def read_file(path: str) -> str:
-    with open(path) as file:
-        return file.read()

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -12,6 +12,8 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+import os
+import stat
 from tempfile import NamedTemporaryFile
 from typing import Any
 from unittest.mock import MagicMock, patch
@@ -166,26 +168,109 @@ def test_get_https_proxy_url_no_proxy(source_params: SourceParameters) -> None:
     assert https_proxy_url is None
 
 
-def test_ca_bundle_path_creation_for_server_certificates_with_default_ca_configured(
-    source_params: SourceParameters, on_prem_proxy_uris: list[str], monkeypatch: pytest.MonkeyPatch
+def test_ca_bundle_path_no_server_certificates_returns_default_ca_bundle_path(
+    on_prem_proxy_uris: list[str], monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    source_params_empty_server_certs = SourceParameters(
+        secrets={},
+        https_connections={},
+        client_certificate=None,
+        proxy_token="on-prem-proxy-token",
+        server_certificates={},
+        resolved_source_credentials=None,
+    )
+
+    monkeypatch.delenv("REQUESTS_CA_BUNDLE", raising=False)
     with NamedTemporaryFile(delete=False, mode="w") as default_ca:
         default_ca.write("default_ca_value\n")
         monkeypatch.setenv("REQUESTS_CA_BUNDLE", default_ca.name)
 
-    source = Source(source_params, on_prem_proxy_uris, [], None, None)
-    ca_bundle_path = source._ca_bundle_path
+    with NamedTemporaryFile(delete=False, mode="w") as custom_ca:
+        custom_ca.write("custom_ca_value\n")
+        source_with_provided_ca_bundle = Source(
+            source_params_empty_server_certs,
+            on_prem_proxy_uris,
+            [],
+            None,
+            None,
+            ca_bundle_path=custom_ca.name,
+        )
 
-    assert ca_bundle_path is not None
-    with open(ca_bundle_path) as f:
+    source_with_requests_ca_bundle = Source(
+        source_params_empty_server_certs,
+        on_prem_proxy_uris,
+        [],
+        None,
+        None,
+    )
+
+    assert source_with_requests_ca_bundle._ca_bundle_path == default_ca.name
+    assert source_with_provided_ca_bundle._ca_bundle_path == custom_ca.name
+
+    with open(source_with_requests_ca_bundle._ca_bundle_path) as f:
         ca_contents = f.read()
-        assert ca_contents == "default_ca_value\nserver_ca_value\nother_server_ca_value\n"
+        assert ca_contents == "default_ca_value\n"
+
+    with open(source_with_provided_ca_bundle._ca_bundle_path) as f:
+        ca_contents = f.read()
+        assert ca_contents == "custom_ca_value\n"
 
 
-def test_ca_bundle_path_creation_for_server_certificates_with_no_default_ca_configured(
+def test_ca_bundle_path_creation_for_server_certificates_with_no_provided_ca_configured(
     source_params: SourceParameters, on_prem_proxy_uris: list[str], monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.delenv("REQUESTS_CA_BUNDLE", raising=False)
+
+    source = Source(source_params, on_prem_proxy_uris, [], None, None)
+
+    assert source._ca_bundle_path is not None
+    with open(source._ca_bundle_path) as f:
+        ca_contents = f.read()
+        assert ca_contents == "server_ca_value\nother_server_ca_value\n"
+
+
+def test_ca_bundle_path_creation_for_server_certificates_with_provided_ca_configured(
+    source_params: SourceParameters, on_prem_proxy_uris: list[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("REQUESTS_CA_BUNDLE", raising=False)
+    with NamedTemporaryFile(delete=False, mode="w") as default_ca:
+        default_ca.write("default_ca_value\n")
+        monkeypatch.setenv("REQUESTS_CA_BUNDLE", default_ca.name)
+
+    with NamedTemporaryFile(delete=False, mode="w") as custom_ca:
+        custom_ca.write("custom_ca_value\n")
+        source_with_provided_ca_bundle = Source(
+            source_params,
+            on_prem_proxy_uris,
+            [],
+            None,
+            None,
+            ca_bundle_path=custom_ca.name,
+        )
+
+    source_with_requests_ca_bundle = Source(source_params, on_prem_proxy_uris, [], None, None)
+
+    assert source_with_requests_ca_bundle._ca_bundle_path is not None
+    assert source_with_provided_ca_bundle._ca_bundle_path == custom_ca.name
+
+    with open(source_with_requests_ca_bundle._ca_bundle_path) as f:
+        ca_contents = f.read()
+        assert ca_contents == "default_ca_value\nserver_ca_value\nother_server_ca_value\n"
+
+    with open(source_with_provided_ca_bundle._ca_bundle_path) as f:
+        ca_contents = f.read()
+        assert ca_contents == "custom_ca_value\nserver_ca_value\nother_server_ca_value\n"
+
+
+def test_ca_bundle_path_creation_defaults_to_temporary_file_if_no_permission_to_write_to_provided_ca_bundle(
+    source_params: SourceParameters, on_prem_proxy_uris: list[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("REQUESTS_CA_BUNDLE", raising=False)
+    with NamedTemporaryFile(delete=False, mode="w") as requests_ca_bundle:
+        requests_ca_bundle.write("requests_ca_bundle_value\n")
+        current_permissions = os.stat(requests_ca_bundle.name).st_mode
+        readonly_permissions = current_permissions & ~(stat.S_IWUSR | stat.S_IWGRP | stat.S_IWOTH)
+        os.chmod(requests_ca_bundle.name, readonly_permissions)
 
     source = Source(source_params, on_prem_proxy_uris, [], None, None)
     ca_bundle_path = source._ca_bundle_path
@@ -196,45 +281,15 @@ def test_ca_bundle_path_creation_for_server_certificates_with_no_default_ca_conf
         assert ca_contents == "server_ca_value\nother_server_ca_value\n"
 
 
-def test_ca_bundle_path_creation_for_server_certificates_uses_custom_ca_bundle_path(
+def test_ca_bundle_path_creation_defaults_to_temporary_file_if_no_permission_to_read_to_provided_ca_bundle(
     source_params: SourceParameters, on_prem_proxy_uris: list[str], monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.delenv("REQUESTS_CA_BUNDLE", raising=False)
-    with NamedTemporaryFile(delete=False, mode="w") as default_ca:
-        default_ca.write("my_ca_value\n")
-
-    source = Source(source_params, on_prem_proxy_uris, [], None, None, ca_bundle_path=default_ca.name)
-    ca_bundle_path = source._ca_bundle_path
-
-    assert ca_bundle_path is not None
-    with open(ca_bundle_path) as f:
-        ca_contents = f.read()
-        assert ca_contents == "my_ca_value\nserver_ca_value\nother_server_ca_value\n"
-
-
-def test_ca_bundle_path_creation_does_not_use_requests_ca_bundle_if_custom_ca_bundle_configured(
-    source_params: SourceParameters, on_prem_proxy_uris: list[str], monkeypatch: pytest.MonkeyPatch
-) -> None:
     with NamedTemporaryFile(delete=False, mode="w") as requests_ca_bundle:
         requests_ca_bundle.write("requests_ca_bundle_value\n")
-        monkeypatch.setenv("REQUESTS_CA_BUNDLE", requests_ca_bundle.name)
-
-    with NamedTemporaryFile(delete=False, mode="w") as default_ca:
-        default_ca.write("default_ca_value\n")
-
-    source = Source(source_params, on_prem_proxy_uris, [], None, None, ca_bundle_path=default_ca.name)
-    ca_bundle_path = source._ca_bundle_path
-
-    assert ca_bundle_path is not None
-    with open(ca_bundle_path) as f:
-        ca_contents = f.read()
-        assert ca_contents == "default_ca_value\nserver_ca_value\nother_server_ca_value\n"
-
-
-def test_ca_bundle_path_creation_defaults_to_temporary_file_if_no_custom_ca_bundle_path_or_requests_ca_bundle_configured(
-    source_params: SourceParameters, on_prem_proxy_uris: list[str], monkeypatch: pytest.MonkeyPatch
-) -> None:
-    monkeypatch.delenv("REQUESTS_CA_BUNDLE", raising=False)
+        current_permissions = os.stat(requests_ca_bundle.name).st_mode
+        readonly_permissions = current_permissions & ~(stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH)
+        os.chmod(requests_ca_bundle.name, readonly_permissions)
 
     source = Source(source_params, on_prem_proxy_uris, [], None, None)
     ca_bundle_path = source._ca_bundle_path

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -43,7 +43,7 @@ def source_params() -> SourceParameters:
         },
         client_certificate=ClientCertificate(pem_certificate="cert", pem_private_key="key"),
         proxy_token="on-prem-proxy-token",
-        server_certificates={"my_server_ca": "server_ca_value"},
+        server_certificates={"my_server_ca": "server_ca_value", "other_server_ca": "other_server_ca_value"},
         resolved_source_credentials=AwsCredentials(
             access_key_id="access-key",
             secret_access_key="secret",
@@ -170,7 +170,7 @@ def test_ca_bundle_path_creation_for_server_certificates_with_default_ca_configu
     source_params: SourceParameters, on_prem_proxy_uris: list[str], monkeypatch: pytest.MonkeyPatch
 ) -> None:
     with NamedTemporaryFile(delete=False, mode="w") as default_ca:
-        default_ca.write("default_ca_value")
+        default_ca.write("default_ca_value\n")
         monkeypatch.setenv("REQUESTS_CA_BUNDLE", default_ca.name)
 
     source = Source(source_params, on_prem_proxy_uris, [], None, None)
@@ -179,7 +179,7 @@ def test_ca_bundle_path_creation_for_server_certificates_with_default_ca_configu
     assert ca_bundle_path is not None
     with open(ca_bundle_path) as f:
         ca_contents = f.read()
-        assert ca_contents == "default_ca_value\nserver_ca_value\n"
+        assert ca_contents == "default_ca_value\nserver_ca_value\nother_server_ca_value\n"
 
 
 def test_ca_bundle_path_creation_for_server_certificates_with_no_default_ca_configured(
@@ -193,7 +193,7 @@ def test_ca_bundle_path_creation_for_server_certificates_with_no_default_ca_conf
     assert ca_bundle_path is not None
     with open(ca_bundle_path) as f:
         ca_contents = f.read()
-        assert ca_contents == "server_ca_value\n"
+        assert ca_contents == "server_ca_value\nother_server_ca_value\n"
 
 
 def test_ca_bundle_path_creation_for_server_certificates_uses_custom_ca_bundle_path(
@@ -209,7 +209,7 @@ def test_ca_bundle_path_creation_for_server_certificates_uses_custom_ca_bundle_p
     assert ca_bundle_path is not None
     with open(ca_bundle_path) as f:
         ca_contents = f.read()
-        assert ca_contents == "my_ca_value\n\nserver_ca_value\n"
+        assert ca_contents == "my_ca_value\nserver_ca_value\nother_server_ca_value\n"
 
 
 def test_ca_bundle_path_creation_does_not_use_requests_ca_bundle_if_custom_ca_bundle_configured(
@@ -228,7 +228,21 @@ def test_ca_bundle_path_creation_does_not_use_requests_ca_bundle_if_custom_ca_bu
     assert ca_bundle_path is not None
     with open(ca_bundle_path) as f:
         ca_contents = f.read()
-        assert ca_contents == "default_ca_value\n\nserver_ca_value\n"
+        assert ca_contents == "default_ca_value\nserver_ca_value\nother_server_ca_value\n"
+
+
+def test_ca_bundle_path_creation_defaults_to_temporary_file_if_no_custom_ca_bundle_path_or_requests_ca_bundle_configured(
+    source_params: SourceParameters, on_prem_proxy_uris: list[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("REQUESTS_CA_BUNDLE", raising=False)
+
+    source = Source(source_params, on_prem_proxy_uris, [], None, None)
+    ca_bundle_path = source._ca_bundle_path
+
+    assert ca_bundle_path is not None
+    with open(ca_bundle_path) as f:
+        ca_contents = f.read()
+        assert ca_contents == "server_ca_value\nother_server_ca_value\n"
 
 
 @patch("external_systems.sources._sources.create_socket")

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -15,7 +15,7 @@
 import os
 import stat
 from tempfile import NamedTemporaryFile
-from typing import Any
+from typing import Any, cast
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -271,33 +271,20 @@ def test_ca_bundle_path_creation_defaults_to_temporary_file_if_no_permission_to_
         current_permissions = os.stat(requests_ca_bundle.name).st_mode
         readonly_permissions = current_permissions & ~(stat.S_IWUSR | stat.S_IWGRP | stat.S_IWOTH)
         os.chmod(requests_ca_bundle.name, readonly_permissions)
+        monkeypatch.setenv("REQUESTS_CA_BUNDLE", requests_ca_bundle.name)
 
     source = Source(source_params, on_prem_proxy_uris, [], None, None)
     ca_bundle_path = source._ca_bundle_path
 
-    assert ca_bundle_path is not None
-    with open(ca_bundle_path) as f:
+    assert os.getenv("REQUESTS_CA_BUNDLE") is not None
+    with open(cast(str, os.getenv("REQUESTS_CA_BUNDLE"))) as f:
         ca_contents = f.read()
-        assert ca_contents == "server_ca_value\nother_server_ca_value\n"
-
-
-def test_ca_bundle_path_creation_defaults_to_temporary_file_if_no_permission_to_read_to_provided_ca_bundle(
-    source_params: SourceParameters, on_prem_proxy_uris: list[str], monkeypatch: pytest.MonkeyPatch
-) -> None:
-    monkeypatch.delenv("REQUESTS_CA_BUNDLE", raising=False)
-    with NamedTemporaryFile(delete=False, mode="w") as requests_ca_bundle:
-        requests_ca_bundle.write("requests_ca_bundle_value\n")
-        current_permissions = os.stat(requests_ca_bundle.name).st_mode
-        readonly_permissions = current_permissions & ~(stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH)
-        os.chmod(requests_ca_bundle.name, readonly_permissions)
-
-    source = Source(source_params, on_prem_proxy_uris, [], None, None)
-    ca_bundle_path = source._ca_bundle_path
+        assert ca_contents == "requests_ca_bundle_value\n"
 
     assert ca_bundle_path is not None
     with open(ca_bundle_path) as f:
         ca_contents = f.read()
-        assert ca_contents == "server_ca_value\nother_server_ca_value\n"
+        assert ca_contents == "requests_ca_bundle_value\n\nserver_ca_value\nother_server_ca_value\n"
 
 
 @patch("external_systems.sources._sources.create_socket")


### PR DESCRIPTION
## Before this PR

Running into issues with CA bundles on different environments + formatting on Source defined server certs.

## After this PR

Create a more robust implementation that aligns better with how majority of python HTTP libraries operate