### PR TITLE
Temp fix for spark UDFs

### DIFF
--- a/changelog/@unreleased/pr-13.v2.yml
+++ b/changelog/@unreleased/pr-13.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Fix
+  links:
+  - https://github.com/palantir/external-systems/pull/13

--- a/external_systems/sources/_proxies.py
+++ b/external_systems/sources/_proxies.py
@@ -19,6 +19,7 @@ from requests import PreparedRequest, Response, Session
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
+import os
 
 class CustomCaBundleSession(Session):
     """
@@ -28,7 +29,7 @@ class CustomCaBundleSession(Session):
     """
 
     def merge_environment_settings(self, url, proxies, stream, verify, *args, **kwargs):  # type: ignore[no-untyped-def]
-        if isinstance(self.verify, str):
+        if isinstance(self.verify, str) and os.path.exists(self.verify):
             verify = self.verify
 
         return super(CustomCaBundleSession, self).merge_environment_settings(

--- a/external_systems/sources/_proxies.py
+++ b/external_systems/sources/_proxies.py
@@ -12,6 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+import os
 from functools import cache
 from typing import Any, Mapping, Optional, Union
 
@@ -19,7 +20,6 @@ from requests import PreparedRequest, Response, Session
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
-import os
 
 class CustomCaBundleSession(Session):
     """


### PR DESCRIPTION
## Before this PR
Spark executors (UDFs) run in a different pod/container with it's own isolated filesystem. We generate and cache the file path of a CA bundle when the HTTP/Session object is first instantiated. This means if a source HTTP/Session client was instantiated outside the UDF and only that object was passed into the UDF the HTTP request will fail with a file not found error when it tries to search that file path for a CA bundle

## After this PR
In our Session wrapper add logic to check if the CA bundle file does not exist, and default back to use the `REQUESTS_CA_BUNDLE` environment variable default since all Spark executors have this available