### PR TITLE
expose ca_bundle_path location

### DIFF
--- a/changelog/@unreleased/pr-15.v2.yml
+++ b/changelog/@unreleased/pr-15.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: expose ca_bundle_path location
+  links:
+  - https://github.com/palantir/external-systems/pull/15

--- a/external_systems/sources/_sources.py
+++ b/external_systems/sources/_sources.py
@@ -75,13 +75,18 @@ class Source:
     def _https_connections(self) -> Mapping[str, HttpsConnection]:
         return frozendict(
             {
-                key: HttpsConnection(params, self._client_certificate, self._https_proxy_url, self.ca_bundle_path)
+                key: HttpsConnection(params, self._client_certificate, self._https_proxy_url, self.server_certificates)
                 for key, params in self._source_parameters.https_connections.items()
             }
         )
 
     @property
-    def ca_bundle_path(self) -> Optional[str]:
+    def server_certificates(self) -> Optional[str]:
+        """
+        File path to the CA bundle file containing all server certificates required by the Source.
+        If no server certificates are defined on the Source, this will return None.
+        """
+
         if self._source_parameters.server_certificates is None:
             return None
 
@@ -139,9 +144,9 @@ class Source:
             )
         elif egress_proxy_configured:
             # we checked this earlier, but assert again here to make mypy happy
-            assert (
-                self._egress_proxy_token is not None
-            ), "no egress proxy parameters found while configuring egress proxy session"
+            assert self._egress_proxy_token is not None, (
+                "no egress proxy parameters found while configuring egress proxy session"
+            )
             if len(self._egress_proxy_service_uris) == 0:
                 raise ValueError("egress proxy was configured for this source, but egress proxy URIs were not present")
             return create_proxy_session(self._https_proxy_url, self._egress_proxy_token)

--- a/external_systems/sources/_sources.py
+++ b/external_systems/sources/_sources.py
@@ -139,9 +139,9 @@ class Source:
             )
         elif egress_proxy_configured:
             # we checked this earlier, but assert again here to make mypy happy
-            assert self._egress_proxy_token is not None, (
-                "no egress proxy parameters found while configuring egress proxy session"
-            )
+            assert (
+                self._egress_proxy_token is not None
+            ), "no egress proxy parameters found while configuring egress proxy session"
             if len(self._egress_proxy_service_uris) == 0:
                 raise ValueError("egress proxy was configured for this source, but egress proxy URIs were not present")
             return create_proxy_session(self._https_proxy_url, self._egress_proxy_token)

--- a/external_systems/sources/_sources.py
+++ b/external_systems/sources/_sources.py
@@ -75,13 +75,15 @@ class Source:
     def _https_connections(self) -> Mapping[str, HttpsConnection]:
         return frozendict(
             {
-                key: HttpsConnection(params, self._client_certificate, self._https_proxy_url, self.server_certificates)
+                key: HttpsConnection(
+                    params, self._client_certificate, self._https_proxy_url, self.server_certificates_path
+                )
                 for key, params in self._source_parameters.https_connections.items()
             }
         )
 
     @property
-    def server_certificates(self) -> Optional[str]:
+    def server_certificates_path(self) -> Optional[str]:
         """
         File path to the CA bundle file containing all server certificates required by the Source.
         If no server certificates are defined on the Source, this will return None.

--- a/external_systems/sources/_sources.py
+++ b/external_systems/sources/_sources.py
@@ -146,9 +146,9 @@ class Source:
             )
         elif egress_proxy_configured:
             # we checked this earlier, but assert again here to make mypy happy
-            assert self._egress_proxy_token is not None, (
-                "no egress proxy parameters found while configuring egress proxy session"
-            )
+            assert (
+                self._egress_proxy_token is not None
+            ), "no egress proxy parameters found while configuring egress proxy session"
             if len(self._egress_proxy_service_uris) == 0:
                 raise ValueError("egress proxy was configured for this source, but egress proxy URIs were not present")
             return create_proxy_session(self._https_proxy_url, self._egress_proxy_token)

--- a/external_systems/sources/_sources.py
+++ b/external_systems/sources/_sources.py
@@ -75,13 +75,13 @@ class Source:
     def _https_connections(self) -> Mapping[str, HttpsConnection]:
         return frozendict(
             {
-                key: HttpsConnection(params, self._client_certificate, self._https_proxy_url, self._ca_bundle_path)
+                key: HttpsConnection(params, self._client_certificate, self._https_proxy_url, self.ca_bundle_path)
                 for key, params in self._source_parameters.https_connections.items()
             }
         )
 
-    @cached_property
-    def _ca_bundle_path(self) -> Optional[str]:
+    @property
+    def ca_bundle_path(self) -> Optional[str]:
         if self._source_parameters.server_certificates is None:
             return None
 
@@ -139,9 +139,9 @@ class Source:
             )
         elif egress_proxy_configured:
             # we checked this earlier, but assert again here to make mypy happy
-            assert (
-                self._egress_proxy_token is not None
-            ), "no egress proxy parameters found while configuring egress proxy session"
+            assert self._egress_proxy_token is not None, (
+                "no egress proxy parameters found while configuring egress proxy session"
+            )
             if len(self._egress_proxy_service_uris) == 0:
                 raise ValueError("egress proxy was configured for this source, but egress proxy URIs were not present")
             return create_proxy_session(self._https_proxy_url, self._egress_proxy_token)

--- a/external_systems/sources/_sources.py
+++ b/external_systems/sources/_sources.py
@@ -144,9 +144,9 @@ class Source:
             )
         elif egress_proxy_configured:
             # we checked this earlier, but assert again here to make mypy happy
-            assert self._egress_proxy_token is not None, (
-                "no egress proxy parameters found while configuring egress proxy session"
-            )
+            assert (
+                self._egress_proxy_token is not None
+            ), "no egress proxy parameters found while configuring egress proxy session"
             if len(self._egress_proxy_service_uris) == 0:
                 raise ValueError("egress proxy was configured for this source, but egress proxy URIs were not present")
             return create_proxy_session(self._https_proxy_url, self._egress_proxy_token)

--- a/external_systems/sources/_sources.py
+++ b/external_systems/sources/_sources.py
@@ -76,14 +76,14 @@ class Source:
         return frozendict(
             {
                 key: HttpsConnection(
-                    params, self._client_certificate, self._https_proxy_url, self.server_certificates_path
+                    params, self._client_certificate, self._https_proxy_url, self.server_certificates_file_path
                 )
                 for key, params in self._source_parameters.https_connections.items()
             }
         )
 
     @property
-    def server_certificates_path(self) -> Optional[str]:
+    def server_certificates_file_path(self) -> Optional[str]:
         """
         File path to the CA bundle file containing all server certificates required by the Source.
         If no server certificates are defined on the Source, this will return None.
@@ -146,9 +146,9 @@ class Source:
             )
         elif egress_proxy_configured:
             # we checked this earlier, but assert again here to make mypy happy
-            assert (
-                self._egress_proxy_token is not None
-            ), "no egress proxy parameters found while configuring egress proxy session"
+            assert self._egress_proxy_token is not None, (
+                "no egress proxy parameters found while configuring egress proxy session"
+            )
             if len(self._egress_proxy_service_uris) == 0:
                 raise ValueError("egress proxy was configured for this source, but egress proxy URIs were not present")
             return create_proxy_session(self._https_proxy_url, self._egress_proxy_token)

--- a/external_systems/sources/_sources.py
+++ b/external_systems/sources/_sources.py
@@ -76,14 +76,14 @@ class Source:
         return frozendict(
             {
                 key: HttpsConnection(
-                    params, self._client_certificate, self._https_proxy_url, self.server_certificates_file_path
+                    params, self._client_certificate, self._https_proxy_url, self.server_certificates_bundle_path
                 )
                 for key, params in self._source_parameters.https_connections.items()
             }
         )
 
     @property
-    def server_certificates_file_path(self) -> Optional[str]:
+    def server_certificates_bundle_path(self) -> Optional[str]:
         """
         File path to the CA bundle file containing all server certificates required by the Source.
         If no server certificates are defined on the Source, this will return None.

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -174,7 +174,7 @@ def test_ca_bundle_path_creation_for_server_certificates_with_default_ca_configu
         monkeypatch.setenv("REQUESTS_CA_BUNDLE", default_ca.name)
 
     source = Source(source_params, on_prem_proxy_uris, [], None, None)
-    ca_bundle_path = source._ca_bundle_path
+    ca_bundle_path = source.ca_bundle_path
 
     assert ca_bundle_path is not None
     with open(ca_bundle_path) as f:
@@ -188,7 +188,7 @@ def test_ca_bundle_path_creation_for_server_certificates_with_no_default_ca_conf
     monkeypatch.delenv("REQUESTS_CA_BUNDLE", raising=False)
 
     source = Source(source_params, on_prem_proxy_uris, [], None, None)
-    ca_bundle_path = source._ca_bundle_path
+    ca_bundle_path = source.ca_bundle_path
 
     assert ca_bundle_path is not None
     with open(ca_bundle_path) as f:
@@ -204,7 +204,7 @@ def test_ca_bundle_path_creation_for_server_certificates_uses_custom_ca_bundle_p
         default_ca.write("my_ca_value\n")
 
     source = Source(source_params, on_prem_proxy_uris, [], None, None, ca_bundle_path=default_ca.name)
-    ca_bundle_path = source._ca_bundle_path
+    ca_bundle_path = source.ca_bundle_path
 
     assert ca_bundle_path is not None
     with open(ca_bundle_path) as f:
@@ -223,7 +223,7 @@ def test_ca_bundle_path_creation_does_not_use_requests_ca_bundle_if_custom_ca_bu
         default_ca.write("default_ca_value\n")
 
     source = Source(source_params, on_prem_proxy_uris, [], None, None, ca_bundle_path=default_ca.name)
-    ca_bundle_path = source._ca_bundle_path
+    ca_bundle_path = source.ca_bundle_path
 
     assert ca_bundle_path is not None
     with open(ca_bundle_path) as f:

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -174,7 +174,7 @@ def test_ca_bundle_path_creation_for_server_certificates_with_default_ca_configu
         monkeypatch.setenv("REQUESTS_CA_BUNDLE", default_ca.name)
 
     source = Source(source_params, on_prem_proxy_uris, [], None, None)
-    ca_bundle_path = source.ca_bundle_path
+    ca_bundle_path = source.server_certificates
 
     assert ca_bundle_path is not None
     with open(ca_bundle_path) as f:
@@ -188,7 +188,7 @@ def test_ca_bundle_path_creation_for_server_certificates_with_no_default_ca_conf
     monkeypatch.delenv("REQUESTS_CA_BUNDLE", raising=False)
 
     source = Source(source_params, on_prem_proxy_uris, [], None, None)
-    ca_bundle_path = source.ca_bundle_path
+    ca_bundle_path = source.server_certificates
 
     assert ca_bundle_path is not None
     with open(ca_bundle_path) as f:
@@ -204,7 +204,7 @@ def test_ca_bundle_path_creation_for_server_certificates_uses_custom_ca_bundle_p
         default_ca.write("my_ca_value\n")
 
     source = Source(source_params, on_prem_proxy_uris, [], None, None, ca_bundle_path=default_ca.name)
-    ca_bundle_path = source.ca_bundle_path
+    ca_bundle_path = source.server_certificates
 
     assert ca_bundle_path is not None
     with open(ca_bundle_path) as f:
@@ -223,7 +223,7 @@ def test_ca_bundle_path_creation_does_not_use_requests_ca_bundle_if_custom_ca_bu
         default_ca.write("default_ca_value\n")
 
     source = Source(source_params, on_prem_proxy_uris, [], None, None, ca_bundle_path=default_ca.name)
-    ca_bundle_path = source.ca_bundle_path
+    ca_bundle_path = source.server_certificates
 
     assert ca_bundle_path is not None
     with open(ca_bundle_path) as f:

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -174,7 +174,7 @@ def test_ca_bundle_path_creation_for_server_certificates_with_default_ca_configu
         monkeypatch.setenv("REQUESTS_CA_BUNDLE", default_ca.name)
 
     source = Source(source_params, on_prem_proxy_uris, [], None, None)
-    ca_bundle_path = source.server_certificates_path
+    ca_bundle_path = source.server_certificates_file_path
 
     assert ca_bundle_path is not None
     with open(ca_bundle_path) as f:
@@ -188,7 +188,7 @@ def test_ca_bundle_path_creation_for_server_certificates_with_no_default_ca_conf
     monkeypatch.delenv("REQUESTS_CA_BUNDLE", raising=False)
 
     source = Source(source_params, on_prem_proxy_uris, [], None, None)
-    ca_bundle_path = source.server_certificates_path
+    ca_bundle_path = source.server_certificates_file_path
 
     assert ca_bundle_path is not None
     with open(ca_bundle_path) as f:
@@ -204,7 +204,7 @@ def test_ca_bundle_path_creation_for_server_certificates_uses_custom_ca_bundle_p
         default_ca.write("my_ca_value\n")
 
     source = Source(source_params, on_prem_proxy_uris, [], None, None, ca_bundle_path=default_ca.name)
-    ca_bundle_path = source.server_certificates_path
+    ca_bundle_path = source.server_certificates_file_path
 
     assert ca_bundle_path is not None
     with open(ca_bundle_path) as f:
@@ -223,7 +223,7 @@ def test_ca_bundle_path_creation_does_not_use_requests_ca_bundle_if_custom_ca_bu
         default_ca.write("default_ca_value\n")
 
     source = Source(source_params, on_prem_proxy_uris, [], None, None, ca_bundle_path=default_ca.name)
-    ca_bundle_path = source.server_certificates_path
+    ca_bundle_path = source.server_certificates_file_path
 
     assert ca_bundle_path is not None
     with open(ca_bundle_path) as f:

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -174,7 +174,7 @@ def test_ca_bundle_path_creation_for_server_certificates_with_default_ca_configu
         monkeypatch.setenv("REQUESTS_CA_BUNDLE", default_ca.name)
 
     source = Source(source_params, on_prem_proxy_uris, [], None, None)
-    ca_bundle_path = source.server_certificates_file_path
+    ca_bundle_path = source.server_certificates_bundle_path
 
     assert ca_bundle_path is not None
     with open(ca_bundle_path) as f:
@@ -188,7 +188,7 @@ def test_ca_bundle_path_creation_for_server_certificates_with_no_default_ca_conf
     monkeypatch.delenv("REQUESTS_CA_BUNDLE", raising=False)
 
     source = Source(source_params, on_prem_proxy_uris, [], None, None)
-    ca_bundle_path = source.server_certificates_file_path
+    ca_bundle_path = source.server_certificates_bundle_path
 
     assert ca_bundle_path is not None
     with open(ca_bundle_path) as f:
@@ -204,7 +204,7 @@ def test_ca_bundle_path_creation_for_server_certificates_uses_custom_ca_bundle_p
         default_ca.write("my_ca_value\n")
 
     source = Source(source_params, on_prem_proxy_uris, [], None, None, ca_bundle_path=default_ca.name)
-    ca_bundle_path = source.server_certificates_file_path
+    ca_bundle_path = source.server_certificates_bundle_path
 
     assert ca_bundle_path is not None
     with open(ca_bundle_path) as f:
@@ -223,7 +223,7 @@ def test_ca_bundle_path_creation_does_not_use_requests_ca_bundle_if_custom_ca_bu
         default_ca.write("default_ca_value\n")
 
     source = Source(source_params, on_prem_proxy_uris, [], None, None, ca_bundle_path=default_ca.name)
-    ca_bundle_path = source.server_certificates_file_path
+    ca_bundle_path = source.server_certificates_bundle_path
 
     assert ca_bundle_path is not None
     with open(ca_bundle_path) as f:

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -174,7 +174,7 @@ def test_ca_bundle_path_creation_for_server_certificates_with_default_ca_configu
         monkeypatch.setenv("REQUESTS_CA_BUNDLE", default_ca.name)
 
     source = Source(source_params, on_prem_proxy_uris, [], None, None)
-    ca_bundle_path = source.server_certificates
+    ca_bundle_path = source.server_certificates_path
 
     assert ca_bundle_path is not None
     with open(ca_bundle_path) as f:
@@ -188,7 +188,7 @@ def test_ca_bundle_path_creation_for_server_certificates_with_no_default_ca_conf
     monkeypatch.delenv("REQUESTS_CA_BUNDLE", raising=False)
 
     source = Source(source_params, on_prem_proxy_uris, [], None, None)
-    ca_bundle_path = source.server_certificates
+    ca_bundle_path = source.server_certificates_path
 
     assert ca_bundle_path is not None
     with open(ca_bundle_path) as f:
@@ -204,7 +204,7 @@ def test_ca_bundle_path_creation_for_server_certificates_uses_custom_ca_bundle_p
         default_ca.write("my_ca_value\n")
 
     source = Source(source_params, on_prem_proxy_uris, [], None, None, ca_bundle_path=default_ca.name)
-    ca_bundle_path = source.server_certificates
+    ca_bundle_path = source.server_certificates_path
 
     assert ca_bundle_path is not None
     with open(ca_bundle_path) as f:
@@ -223,7 +223,7 @@ def test_ca_bundle_path_creation_does_not_use_requests_ca_bundle_if_custom_ca_bu
         default_ca.write("default_ca_value\n")
 
     source = Source(source_params, on_prem_proxy_uris, [], None, None, ca_bundle_path=default_ca.name)
-    ca_bundle_path = source.server_certificates
+    ca_bundle_path = source.server_certificates_path
 
     assert ca_bundle_path is not None
     with open(ca_bundle_path) as f:


### PR DESCRIPTION
## Before this PR

There are cases where customers want to be able to create their own `Session` / requests object and as such a result need access to our provided trusted CA bundle + source certificates.

## After this PR

Expose the CA bundle path property on the source

## Possible downsides?

 We no longer cache the CA bundle which is fine because the only place this is used internally is for the HTTP connections construction which itself is a cached property. This also helps deconflict possibly mutability issues by decoupling the bundle that the HTTP connection object uses vs the one we provide to the user