### PR TITLE
Support GCP oauth creds

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,18 +52,21 @@ my_source: Source = ...
 some_secret: str = my_source.get_secret("SECRET_NAME")
 ```
 
-For sources using session credentials we support credentials generation and refresh management. Currently on an S3 source you can access session credentials using `get_aws_credentials()`. This method will throw if the source is not pre-configured with `AwsCredentials`
+For sources using session credentials we support credentials generation and refresh management. This can be done by using `get_session_credentials` which supports `S3`, `BigQuery`, `Google Cloud Storage` sources.
 
 _Session credentials may not be available in all Foundry runtime environments_
 
 ```python
-from external_systems.sources import Source, Refreshable, AwsCredentials
+from external_systems.sources import Source, Refreshable, SourceCredentials, AwsCredentials
 
 s3_source: Source = ...
 
-refreshable_credentials: Refreshable[AwsCredentials] = s3_source.get_aws_credentials()
+refreshable_credentials: Refreshable[SourceCredentials] = s3_source.get_session_credentials()
 
-session_credentials: AwsCredentials = refreshable_credentials.get()
+session_credentials: SourceCredentials = refreshable_credentials.get()
+
+if not isinstance(session_credentials, AwsCredentials):
+    raise ...
 ```
 
 ## On-prem Connectivity with [Foundry Agent Proxy](https://www.palantir.com/docs/foundry/data-connection/agent-proxy-runtime)

--- a/changelog/@unreleased/pr-16.v2.yml
+++ b/changelog/@unreleased/pr-16.v2.yml
@@ -1,0 +1,5 @@
+type: feature
+feature:
+  description: Support GCP oauth creds
+  links:
+  - https://github.com/palantir/external-systems/pull/16

--- a/external_systems/sources/__init__.py
+++ b/external_systems/sources/__init__.py
@@ -16,6 +16,7 @@ from ._api import (
     AwsCredentials,
     ClientCertificate,
     ClientCertificateFilePaths,
+    GcpOauthCredentials,
     HttpsConnectionParameters,
     SourceCredentials,
     SourceParameters,
@@ -27,6 +28,7 @@ from ._sources import Source
 __all__ = [
     "ClientCertificate",
     "ClientCertificateFilePaths",
+    "GcpOauthCredentials",
     "HttpsConnection",
     "HttpsConnectionParameters",
     "Source",

--- a/external_systems/sources/_api.py
+++ b/external_systems/sources/_api.py
@@ -66,8 +66,14 @@ class AwsCredentials:
     expiration: Optional[datetime] = None
 
 
+@dataclass(frozen=True)
+class GcpOauthCredentials:
+    access_token: str
+    expiration: Optional[datetime] = None
+
+
 # Each new credential type must include an expiration field
-SourceCredentials = Union[AwsCredentials]
+SourceCredentials = Union[AwsCredentials, GcpOauthCredentials]
 
 
 @dataclass(frozen=True)

--- a/external_systems/sources/_sources.py
+++ b/external_systems/sources/_sources.py
@@ -16,9 +16,10 @@ import logging
 import os
 import random
 import socket
+import warnings
 from functools import cached_property
 from tempfile import NamedTemporaryFile
-from typing import Any, Mapping, Optional, Tuple
+from typing import Any, Mapping, Optional, Tuple, cast
 
 import urllib3.util
 from frozendict import frozendict
@@ -197,10 +198,27 @@ class Source:
         Supported Sources:
             - S3
         """
+        warnings.warn(
+            "get_aws_credentials is deprecated and will be removed in a future release. "
+            "Use get_session_credentials instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         if self._maybe_refreshable_resolved_source_credentials is None:
             raise ValueError("Resolved source credentials are not present on the Source.")
         if not isinstance(self._maybe_refreshable_resolved_source_credentials.get(), AwsCredentials):
             raise ValueError("Resolved source credentials are not of type AwsCredentials.")
+        return cast(Refreshable[AwsCredentials], self._maybe_refreshable_resolved_source_credentials)
+
+    def get_session_credentials(self) -> Refreshable[SourceCredentials]:
+        """
+        Get the session credentials from the Source.
+
+        Supported Sources:
+            - S3
+        """
+        if self._maybe_refreshable_resolved_source_credentials is None:
+            raise ValueError("Resolved source credentials are not present on the Source.")
         return self._maybe_refreshable_resolved_source_credentials
 
     def get_secret(self, key: str) -> str:

--- a/external_systems/sources/_sources.py
+++ b/external_systems/sources/_sources.py
@@ -147,9 +147,9 @@ class Source:
             )
         elif egress_proxy_configured:
             # we checked this earlier, but assert again here to make mypy happy
-            assert self._egress_proxy_token is not None, (
-                "no egress proxy parameters found while configuring egress proxy session"
-            )
+            assert (
+                self._egress_proxy_token is not None
+            ), "no egress proxy parameters found while configuring egress proxy session"
             if len(self._egress_proxy_service_uris) == 0:
                 raise ValueError("egress proxy was configured for this source, but egress proxy URIs were not present")
             return create_proxy_session(self._https_proxy_url, self._egress_proxy_token)

--- a/external_systems/sources/_sources.py
+++ b/external_systems/sources/_sources.py
@@ -147,9 +147,9 @@ class Source:
             )
         elif egress_proxy_configured:
             # we checked this earlier, but assert again here to make mypy happy
-            assert (
-                self._egress_proxy_token is not None
-            ), "no egress proxy parameters found while configuring egress proxy session"
+            assert self._egress_proxy_token is not None, (
+                "no egress proxy parameters found while configuring egress proxy session"
+            )
             if len(self._egress_proxy_service_uris) == 0:
                 raise ValueError("egress proxy was configured for this source, but egress proxy URIs were not present")
             return create_proxy_session(self._https_proxy_url, self._egress_proxy_token)
@@ -212,8 +212,6 @@ class Source:
 
     def get_session_credentials(self) -> Refreshable[SourceCredentials]:
         """
-        Get the session credentials from the Source.
-
         Supported Sources:
             - S3
             - BigQuery

--- a/external_systems/sources/_sources.py
+++ b/external_systems/sources/_sources.py
@@ -193,10 +193,7 @@ class Source:
 
     def get_aws_credentials(self) -> Refreshable[AwsCredentials]:
         """
-        Get the AWS credentials from the Source.
-
-        Supported Sources:
-            - S3
+        DEPRECATED: Use get_session_credentials instead.
         """
         warnings.warn(
             "get_aws_credentials is deprecated and will be removed in a future release. "

--- a/external_systems/sources/_sources.py
+++ b/external_systems/sources/_sources.py
@@ -216,6 +216,8 @@ class Source:
 
         Supported Sources:
             - S3
+            - BigQuery
+            - Google Cloud Storage
         """
         if self._maybe_refreshable_resolved_source_credentials is None:
             raise ValueError("Resolved source credentials are not present on the Source.")

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -370,18 +370,18 @@ def test_maybe_refreshable_resolved_source_credentials_without_credentials(
     assert result is None
 
 
-def test_get_aws_credentials_invokes_refreshable(
+def test_get_session_credentials_invokes_refreshable(
     source_params: SourceParameters,
     on_prem_proxy_uris: list[str],
     egress_proxy_uris: list[str],
     egress_proxy_token: str,
 ) -> None:
     source = Source(source_params, on_prem_proxy_uris, egress_proxy_uris, egress_proxy_token, None)
-    aws_credentials = source.get_aws_credentials()
+    aws_credentials = source.get_session_credentials()
     assert aws_credentials is not None
 
 
-def test_get_aws_credentials_no_resolved_source_credentials(
+def test_get_session_credentials_no_resolved_source_credentials(
     source_params: SourceParameters,
     on_prem_proxy_uris: list[str],
     egress_proxy_uris: list[str],
@@ -397,7 +397,7 @@ def test_get_aws_credentials_no_resolved_source_credentials(
     )
     source = Source(source_params_no_credentials, on_prem_proxy_uris, egress_proxy_uris, egress_proxy_token, None)
     with pytest.raises(ValueError, match="Resolved source credentials are not present on the Source."):
-        _ = source.get_aws_credentials()
+        _ = source.get_session_credentials()
 
 
 def test_get_source_url(


### PR DESCRIPTION
## After this PR

Support GCP oauth creds type:
https://developers.google.com/identity/protocols/oauth2

Deprecate `get_aws_credentials`

## Possible Downsides

`get_session_credentials` returns a union type which users will need to parse