### PR TITLE
Add oauth credentials type to source credentials api

### DIFF
--- a/changelog/@unreleased/pr-17.v2.yml
+++ b/changelog/@unreleased/pr-17.v2.yml
@@ -1,0 +1,5 @@
+type: feature
+feature:
+  description: Add oauth credentials type to source credentials api
+  links:
+  - https://github.com/palantir/external-systems/pull/17

--- a/external_systems/sources/__init__.py
+++ b/external_systems/sources/__init__.py
@@ -18,6 +18,7 @@ from ._api import (
     ClientCertificateFilePaths,
     GcpOauthCredentials,
     HttpsConnectionParameters,
+    OauthCredentials,
     SourceCredentials,
     SourceParameters,
 )
@@ -33,6 +34,7 @@ __all__ = [
     "HttpsConnectionParameters",
     "Source",
     "SourceParameters",
+    "OauthCredentials",
     "RefreshHandler",
     "Refreshable",
     "AwsCredentials",

--- a/external_systems/sources/_api.py
+++ b/external_systems/sources/_api.py
@@ -72,8 +72,14 @@ class GcpOauthCredentials:
     expiration: Optional[datetime] = None
 
 
+@dataclass(frozen=True)
+class OauthCredentials:
+    access_token: str
+    expiration: datetime
+
+
 # Each new credential type must include an expiration field
-SourceCredentials = Union[AwsCredentials, GcpOauthCredentials]
+SourceCredentials = Union[AwsCredentials, GcpOauthCredentials, OauthCredentials]
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
## Before this PR

Authorization code grant + client credentials code grant oauth 2.0 client support being expanded across the platform via Outbound Applications, particularly functions environments

## After this PR

Add support for oauth credentials type via the dynamic/session credentials infra