### PR TITLE
Use pyapi-checker to check for API breaks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,6 +43,14 @@ jobs:
       - run: poetry install
       - run: poetry run poe check_license
 
+  check_api:
+    docker:
+      - image: cimg/python:3.12
+    steps:
+      - checkout
+      - run: poetry install
+      - run: poetry run pyapi analyze
+
   circle-all:
     docker:
       - image: node:lts
@@ -74,6 +82,8 @@ workflows:
         <<: *always-run
       - check_license:
         <<: *always-run
+      - check_api:
+        <<: *always-run
       - circle-all:
           <<: *always-run
           requires:
@@ -84,6 +94,7 @@ workflows:
             - mypy
             - check_format
             - check_license
+            - check_api
       - publish:
           requires:
             - circle-all

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,11 @@
 [tool.poetry]
+[project]
 name = "external-systems"
 version = "0.0.0"
 description = "A Python library for interacting with Foundry Sources"
-authors = ["Palantir Technologies, Inc."]
+authors = [
+    { name = "Palantir Technologies Inc." },
+]
 license = "Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/palantir/external-systems"
@@ -26,6 +29,7 @@ black = "24.1.1"
 isort = "5.13.2"
 mypy = "1.9.0"
 ruff = "0.9.7"
+pyapi-checker = {version = "^0.12.0", markers = "python_version >= '3.12'"}
 pytest = "8.0.0"
 pytest-html = "4.1.1"
 poethepoet = "^0.29.0"


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
Add [pyapi-checker](https://github.com/palantir/pyapi-checker/tree/develop) to this repo so API breaks can be checked for and acknowledged. Added pyapi-checker to the dev dependencies and a CI step for it.

Added the project key to the pyproject which should be there and is needed by pyapi-checker, which prompted poetry to warn that the authors entries needed to objects so modified that too.
==COMMIT_MSG==
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

## Are Docs needed?
<!-- Please indicate whether documentation is needed for this PR. -->
