### PR TITLE
Drop python 3.9 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,7 +75,7 @@ workflows:
           name: python-<< matrix.python_version>>
           matrix:
             parameters:
-              python_version: ["3.9", "3.10", "3.11", "3.12"]
+              python_version: ["3.10", "3.11", "3.12"]
       - mypy:
         <<: *always-run
       - check_format:
@@ -87,7 +87,6 @@ workflows:
       - circle-all:
           <<: *always-run
           requires:
-            - python-3.9
             - python-3.10
             - python-3.11
             - python-3.12

--- a/DEV_SETUP.md
+++ b/DEV_SETUP.md
@@ -4,7 +4,7 @@
 
 ## Requirements
 
-* python >= 3.9
+* python >= 3.10
 * [poetry](https://python-poetry.org/docs/)
 
 ## Commands

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ packages = [{ include = "external_systems" }]
 
 [tool.poetry.dependencies]
 frozendict = "^2.4.6"
-python = "^3.9"
+python = "^3.10"
 requests = "^2.32.3"
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

Conda is packaging this already as 3.10 so we should drop here as well.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Drop python 3.9 support

==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

